### PR TITLE
fix: altera API version do Ingress

### DIFF
--- a/infra/orquestrators/rancher-kubernetes/templates/ingress-template.yaml
+++ b/infra/orquestrators/rancher-kubernetes/templates/ingress-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -18,9 +18,13 @@ spec:
   - host: ${APP_HOST}
     http:
       paths:
-      - backend:
-          serviceName: sei-app
-          servicePort: 443
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: sei-app
+            port:
+              number: 443
   tls:
   - hosts:
     - ${APP_HOST}


### PR DESCRIPTION
Utiliza nova versão da API que deixou de ser suportado no 1.22+ . Essa altearção torna o Ingress incopatível com versões abaixo da 1.19. https://kubernetes.io/docs/reference/using-api/deprecation-guide/\#ingress-v122

Closes #7