### PR TITLE
fix: wkhtmltopdf para centos8

### DIFF
--- a/containers/app/app-base/assets/copy-packages.sh
+++ b/containers/app/app-base/assets/copy-packages.sh
@@ -16,6 +16,6 @@ curl -L -O \
     -O \
     https://github.com/spbgovbr/sei-docker-binarios/raw/main/pacoteslinux/uploadprogress.tgz \
     -O \
-    https://github.com/spbgovbr/sei-docker-binarios/raw/main/pacoteslinux/wkhtmltox-0.12.6-1.centos7.x86_64.rpm 
+    https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm 
 
 cd -

--- a/containers/app/app-base/assets/copy-packages.sh
+++ b/containers/app/app-base/assets/copy-packages.sh
@@ -16,6 +16,6 @@ curl -L -O \
     -O \
     https://github.com/spbgovbr/sei-docker-binarios/raw/main/pacoteslinux/uploadprogress.tgz \
     -O \
-    https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm 
+    https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm
 
 cd -

--- a/containers/app/app-base/assets/copy-packages.sh
+++ b/containers/app/app-base/assets/copy-packages.sh
@@ -16,6 +16,6 @@ curl -L -O \
     -O \
     https://github.com/spbgovbr/sei-docker-binarios/raw/main/pacoteslinux/uploadprogress.tgz \
     -O \
-    https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm
+    https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm 
 
 cd -

--- a/containers/app/app-base/assets/install.sh
+++ b/containers/app/app-base/assets/install.sh
@@ -94,7 +94,7 @@ echo "extension=uploadprogress.so" > /etc/php.d/uploadprogress.ini
 cd -
 
 # wkhtml
-rpm -Uvh wkhtmltox-0.12.6-1.centos7.x86_64.rpm
+rpm -Uvh wkhtmltox-0.12.6-1.centos8.x86_64.rpm
 
 # fonts libraries
 rpm -Uvh msttcore-fonts-2.0-3.noarch.rpm


### PR DESCRIPTION
Corrige as bibliotecas linkadas dinamicamente para o Rocky Linux 8